### PR TITLE
Added support for Cyanide & Happiness comic

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ This module iterates on the items on a feed and parse the webpages to create a n
 Supported websites:
 * GoComics
 * Dilbert.com
+* Cyanide & Happiness
 
 > The list of parsers is meant to be extensible, see [`lib/parser.js`](lib/parsers.js).  
 > PRs are welcome.
@@ -31,9 +32,9 @@ into [this](http://leesei-comics-feed.herokuapp.com/embed/http%3A%2F%2Ffeed.dilb
 
 ## Tested on
 
-http://feed.dilbert.com/dilbert/daily_strip  
-http://feeds.feedburner.com/uclick/dilbert-classics
-http://feeds.feedburner.com/Explosm
+- http://feed.dilbert.com/dilbert/daily_strip  
+- http://feeds.feedburner.com/uclick/dilbert-classics
+- http://feeds.feedburner.com/Explosm
 
 ## TODO
 

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ into [this](http://leesei-comics-feed.herokuapp.com/embed/http%3A%2F%2Ffeed.dilb
 
 http://feed.dilbert.com/dilbert/daily_strip  
 http://feeds.feedburner.com/uclick/dilbert-classics
+http://feeds.feedburner.com/Explosm
 
 ## TODO
 

--- a/bin/comics-feed
+++ b/bin/comics-feed
@@ -13,12 +13,6 @@ var argv = require("nomnom")
     flag: true,
     help: "Print processing logs"
   })
-  .option('maxitems', {
-    abbr: 'm',
-    metavar: "N",
-    default: 0,
-    help: "Max items to keep in feed (0 for no max)"
-  })
   .help("Author: ".bold +
     "leesei@gmail.com".underline + "       "+
     "Licence: ".bold + "MIT\n")
@@ -29,8 +23,7 @@ var argv = require("nomnom")
 require('../lib/main.js').embedStrips(
   {
     url: argv.url,
-    verbose: argv.verbose,
-    maxitems: argv.maxitems,
+    verbose: argv.verbose
   },
   function (err, feedXml) {
     if (err) {

--- a/bin/comics-feed
+++ b/bin/comics-feed
@@ -13,6 +13,12 @@ var argv = require("nomnom")
     flag: true,
     help: "Print processing logs"
   })
+  .option('maxitems', {
+	abbr: 'm',
+	metavar: "N",
+	default: 0,
+    help: "Max items to keep in feed (0 for no max)"
+  })
   .help("Author: ".bold +
     "leesei@gmail.com".underline + "       "+
     "Licence: ".bold + "MIT\n")
@@ -23,7 +29,8 @@ var argv = require("nomnom")
 require('../lib/main.js').embedStrips(
   {
     url: argv.url,
-    verbose: argv.verbose
+    verbose: argv.verbose,
+	maxitems: argv.maxitems,
   },
   function (err, feedXml) {
     if (err) {

--- a/bin/comics-feed
+++ b/bin/comics-feed
@@ -14,9 +14,9 @@ var argv = require("nomnom")
     help: "Print processing logs"
   })
   .option('maxitems', {
-	abbr: 'm',
-	metavar: "N",
-	default: 0,
+    abbr: 'm',
+    metavar: "N",
+    default: 0,
     help: "Max items to keep in feed (0 for no max)"
   })
   .help("Author: ".bold +
@@ -30,7 +30,7 @@ require('../lib/main.js').embedStrips(
   {
     url: argv.url,
     verbose: argv.verbose,
-	maxitems: argv.maxitems,
+    maxitems: argv.maxitems,
   },
   function (err, feedXml) {
     if (err) {

--- a/lib/main.js
+++ b/lib/main.js
@@ -70,15 +70,15 @@ function _finalizeFeed(callback) {
 
     _loadStripUrl(stripsParser.scrape, item.url, function (err, url) {
         // console.log('%s => %s', item.title, url);
-		if(err)
-		{
-			item.description = "No image found...";
-		}
-		else
-		{
-			item.description = '<img src="' + url + '"/>';
-		}
-		callback(null, item);
+        if(err)
+        {
+            item.description = "No image found...";
+        }
+        else
+        {
+            item.description = '<img src="' + url + '"/>';
+        }
+        callback(null, item);
     });
   }, function (err, results) {
     if (opts.verbose) {
@@ -160,16 +160,16 @@ function embedStrips(options, callback) {
           var stream = this, item;
           // push all the items to be processed on 'end'
           while ((item = stream.read()) !== null) {
-		      // console.log(item);
-			 
-			  if(opts.maxitems == 0 || items.length < opts.maxitems)
-			  {
-					items.push({
-					  title:  item.title,
-					  url: item.origlink || item.link,
-					  description: ''
-					});
-			  }
+              // console.log(item);
+             
+              if(opts.maxitems == 0 || items.length < opts.maxitems)
+              {
+                    items.push({
+                      title:  item.title,
+                      url: item.origlink || item.link,
+                      description: ''
+                    });
+              }
           }
         })
         .on('end', function () {

--- a/lib/main.js
+++ b/lib/main.js
@@ -66,10 +66,10 @@ function _finalizeFeed(callback) {
   // use map() to maintain the order of the items
   // each() is not stable (may rearrage items)
   async.map(items, function (item, callback) {
-    // console.log('processing %j', item);
+    console.log('processing %j', item);
 
     _loadStripUrl(stripsParser.scrape, item.url, function (err, url) {
-        // console.log('%s => %s', item.title, url);
+        console.log('%s => %s', item.title, url);
         if(err)
         {
             item.description = "No image found...";
@@ -84,7 +84,7 @@ function _finalizeFeed(callback) {
     if (opts.verbose) {
       console.info('Done');
     }
-    // console.log(results);
+    console.log(results);
 
     // loop through the results and insert to out feed
     results.some(function (item) {

--- a/lib/main.js
+++ b/lib/main.js
@@ -168,14 +168,11 @@ function embedStrips(options, callback) {
           while ((item = stream.read()) !== null) {
               // console.log(item);
              
-              if(opts.maxitems == 0 || items.length < opts.maxitems)
-              {
-                    items.push({
-                      title:  item.title,
-                      url: item.origlink || item.link,
-                      description: ''
-                    });
-              }
+              items.push({
+                title:  item.title,
+                url: item.origlink || item.link,
+                description: ''
+              });
           }
         })
         .on('end', function () {

--- a/lib/main.js
+++ b/lib/main.js
@@ -6,7 +6,7 @@
 var async = require('async');
 var cheerio = require('cheerio');
 var fs = require('fs');
-var http = require('follow-redirects').http;
+var http = require('http');
 
 var parsers = require('./parsers');
 
@@ -23,7 +23,7 @@ var feed = null;  // out-feed
 function _initFeed(meta) {
   // create out feed
   feed = new RSS({
-      title: meta.title.replace(/^GoComics.com - /, ''),
+      title: meta.title.replace(/^GoComics.com - /, '') + ' - embedded',
       description: meta.description,
       generator: 'node-comics-scrape',
       feed_url: meta.xmlUrl,
@@ -35,6 +35,12 @@ function _initFeed(meta) {
 
 function _loadStripUrl(scrape, url, callback) {
   // load the url or file and callback with the stripped url
+
+  // To handle weird Cyanide & Happiness redirect, where www.explosm.net redirects to explosm.net
+  // I used to use the follow-redirects module to automatically handle the redirect, but it seems
+  // to have introduced some bad slowdowns/timeouts.
+  url = url.replace("www.explosm.net","explosm.net");
+
   http
     .get(url, function (response) {
       var body = '';
@@ -65,7 +71,7 @@ function _finalizeFeed(callback) {
 
   // use map() to maintain the order of the items
   // each() is not stable (may rearrage items)
-  async.mapSeries(items, function (item, callback) {
+  async.map(items, function (item, callback) {
     console.log('processing %j', item);
 
     _loadStripUrl(stripsParser.scrape, item.url, function (err, url) {

--- a/lib/main.js
+++ b/lib/main.js
@@ -6,7 +6,7 @@
 var async = require('async');
 var cheerio = require('cheerio');
 var fs = require('fs');
-var http = require('http');
+var http = require('follow-redirects').http;
 
 var parsers = require('./parsers');
 
@@ -69,9 +69,16 @@ function _finalizeFeed(callback) {
     // console.log('processing %j', item);
 
     _loadStripUrl(stripsParser.scrape, item.url, function (err, url) {
-      // console.log('%s => %s', item.title, url);
-      item.description = '<img src="' + url + '"/>';
-      callback(null, item);
+        // console.log('%s => %s', item.title, url);
+		if(err)
+		{
+			item.description = "No image found...";
+		}
+		else
+		{
+			item.description = '<img src="' + url + '"/>';
+		}
+		callback(null, item);
     });
   }, function (err, results) {
     if (opts.verbose) {
@@ -153,13 +160,16 @@ function embedStrips(options, callback) {
           var stream = this, item;
           // push all the items to be processed on 'end'
           while ((item = stream.read()) !== null) {
-            // console.log(item);
-
-            items.push({
-              title:  item.title,
-              url: item.origlink || item.link,
-              description: ''
-            });
+		      // console.log(item);
+			 
+			  if(opts.maxitems == 0 || items.length < opts.maxitems)
+			  {
+					items.push({
+					  title:  item.title,
+					  url: item.origlink || item.link,
+					  description: ''
+					});
+			  }
           }
         })
         .on('end', function () {

--- a/lib/main.js
+++ b/lib/main.js
@@ -65,7 +65,7 @@ function _finalizeFeed(callback) {
 
   // use map() to maintain the order of the items
   // each() is not stable (may rearrage items)
-  async.map(items, function (item, callback) {
+  async.mapSeries(items, function (item, callback) {
     console.log('processing %j', item);
 
     _loadStripUrl(stripsParser.scrape, item.url, function (err, url) {

--- a/lib/parsers.js
+++ b/lib/parsers.js
@@ -45,6 +45,46 @@ var parsers = [
 
       callback(null, img);
     }
+  },
+
+  {
+    name: "Cyanide & Happiness",
+    match: function (siteUrl) {
+      return (/.*explosm.net/.test(siteUrl.hostname));
+    },
+    scrape: function (baseUrl, $, callback) {
+      img = $('#maincontent img[alt*="daily"]').attr('src');
+	  if(img)
+	  {
+		  // the image src is relative
+		  img = url.resolve(baseUrl, img);
+	  }
+	  else
+	  {
+		  // Try to see if there's a video instead of a comic
+		  // Ideally I want to embed the video, but for now we'll just embed the
+		  // thumbnail of the video
+		  vid = $('div#videoPlayer > iframe[src*="youtube.com"]').attr('src');
+		  if(vid)
+		  {
+			  var result = vid.match(/embed\/([^\?]+)\?/);
+			  if(result.length>1)
+			  {
+				  var videoid = result[1];
+				  img = "http://i1.ytimg.com/vi/" + videoid + "/hqdefault.jpg";
+			  }
+		  }
+	  }
+
+	  if(img)
+	  {
+		  callback(null, img);
+	  }
+	  else
+      {
+		  callback("error", null);
+      }	  
+    }
   }
 ];
 

--- a/lib/parsers.js
+++ b/lib/parsers.js
@@ -54,36 +54,36 @@ var parsers = [
     },
     scrape: function (baseUrl, $, callback) {
       img = $('#maincontent img[alt*="daily"]').attr('src');
-	  if(img)
-	  {
-		  // the image src is relative
-		  img = url.resolve(baseUrl, img);
-	  }
-	  else
-	  {
-		  // Try to see if there's a video instead of a comic
-		  // Ideally I want to embed the video, but for now we'll just embed the
-		  // thumbnail of the video
-		  vid = $('div#videoPlayer > iframe[src*="youtube.com"]').attr('src');
-		  if(vid)
-		  {
-			  var result = vid.match(/embed\/([^\?]+)\?/);
-			  if(result.length>1)
-			  {
-				  var videoid = result[1];
-				  img = "http://i1.ytimg.com/vi/" + videoid + "/hqdefault.jpg";
-			  }
-		  }
-	  }
-
-	  if(img)
-	  {
-		  callback(null, img);
-	  }
-	  else
+      if(img)
       {
-		  callback("error", null);
-      }	  
+          // the image src is relative
+          img = url.resolve(baseUrl, img);
+      }
+      else
+      {
+          // Try to see if there's a video instead of a comic
+          // Ideally I want to embed the video, but for now we'll just embed the
+          // thumbnail of the video
+          vid = $('div#videoPlayer > iframe[src*="youtube.com"]').attr('src');
+          if(vid)
+          {
+              var result = vid.match(/embed\/([^\?]+)\?/);
+              if(result.length>1)
+              {
+                  var videoid = result[1];
+                  img = "http://i1.ytimg.com/vi/" + videoid + "/hqdefault.jpg";
+              }
+          }
+      }
+
+      if(img)
+      {
+          callback(null, img);
+      }
+      else
+      {
+          callback("error", null);
+      }
     }
   }
 ];

--- a/lib/parsers.js
+++ b/lib/parsers.js
@@ -53,7 +53,7 @@ var parsers = [
       return (/.*explosm.net/.test(siteUrl.hostname));
     },
     scrape: function (baseUrl, $, callback) {
-      img = $('#maincontent img[alt*="daily"]').attr('src');
+      img = $('#main-comic').attr('src');
       if(img)
       {
           // the image src is relative

--- a/package.json
+++ b/package.json
@@ -30,8 +30,7 @@
     "rss": "~0.2.1",
     "feedparser": "~0.16.5",
     "cheerio": "~0.12.4",
-    "nomnom": "~1.6.2",
-    "follow-redirects": "~0.0.3"
+    "nomnom": "~1.6.2"
   },
   "license": "MIT"
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "comics-feed",
   "version": "0.0.7",
-  "homepage": "http://github.com/leesei/node-comics-feed",
+  "homepage": "http://github.com/eguendelman/node-comics-feed",
   "description": "Scrape comics strips from feed, embed the strip images and create a new feed",
   "author": {
     "name": "KY LEE",
@@ -14,10 +14,10 @@
   },
   "repository": {
     "type": "git",
-    "url": "http://github.com/leesei/node-comics-feed"
+    "url": "http://github.com/eguendelman/node-comics-feed"
   },
   "bugs": {
-    "url": "http://github.com/leesei/node-comics-feed/issues"
+    "url": "http://github.com/eguendelman/node-comics-feed/issues"
   },
   "keywords": [
     "rss",
@@ -30,7 +30,8 @@
     "rss": "~0.2.1",
     "feedparser": "~0.16.5",
     "cheerio": "~0.12.4",
-    "nomnom": "~1.6.2"
+    "nomnom": "~1.6.2",
+    "follow-redirects": "~0.0.3"
   },
   "license": "MIT"
 }


### PR DESCRIPTION
Hi,
I've added support for scraping & embedding images / youtube thumbnails from the Cyanide & Happiness comic at http://feeds.feedburner.com/Explosm

There is one ugly bit in lib/main.js where I do:
url = url.replace("www.explosm.net","explosm.net");
because trying to get http data from www.explosm.net results in a redirect (301 I think) which the http module does not happen.  I tried using a different module (follow-redirects) which supposedly wraps http to handle redirects, but that resulted in some very strange timeout issues which I did not get a chance to fully investigate.

There are a few other small changes
- slightly better error handling in _loadStripUrl (in case no image was found, which happens in this specific comic sometimes)
- changed the name of the resulting RSS feed by suffixing with "- embedded".  I just needed a way to distinguish it from the original feed...  
- Sorry that I have uncommented some of the console.log calls...  If you prefer I can comment those out again.

P.S. this is my first time with github, forking, pull requests, etc. so please be gentle. :)
